### PR TITLE
Fixed spelling error in node readme and example js file

### DIFF
--- a/SDKs/Aspose.OCR-Cloud-SDK-for-NodeJS/README.md
+++ b/SDKs/Aspose.OCR-Cloud-SDK-for-NodeJS/README.md
@@ -13,8 +13,8 @@ var assert = require('assert');
 var StorageApi =require("asposestoragecloud")
 var OcrApi = require("asposeocrcloud");
 
-var AppSID = 'XXX'; //sepcify App SID
-var AppKey = 'XXX'; //sepcify App Key
+var AppSID = 'XXX'; //specify App SID
+var AppKey = 'XXX'; //specify App Key
 var config = {'appSid':AppSID,'apiKey':AppKey};
 var data_path = '../data/';
 

--- a/SDKs/Aspose.OCR-Cloud-SDK-for-NodeJS/test/TestOcrApi.js
+++ b/SDKs/Aspose.OCR-Cloud-SDK-for-NodeJS/test/TestOcrApi.js
@@ -3,8 +3,8 @@ var StorageApi = require('asposestoragecloud');
 var OcrApi = require('../lib/OcrApi');
 var assert = require('assert');
 
-var AppSID = 'XXX'; //sepcify App SID
-var AppKey = 'XXX'; //sepcify App Key
+var AppSID = 'XXX'; //specify App SID
+var AppKey = 'XXX'; //specify App Key
 var config = {'appSid':AppSID,'apiKey':AppKey , 'debug' : true};
 var data_path = './data/';
 


### PR DESCRIPTION
I was just checking out your service, and noticed this spelling error of the word 'specify' in the node SDK, and figured I'd fix it real quick. 